### PR TITLE
SOTN: Populate slot data during generation

### DIFF
--- a/worlds/sotn/__init__.py
+++ b/worlds/sotn/__init__.py
@@ -1,4 +1,4 @@
-from typing import ClassVar, Dict, Tuple, TextIO
+from typing import ClassVar, Dict, Tuple, TextIO, Any
 
 import settings, typing
 from worlds.AutoWorld import WebWorld, World
@@ -445,6 +445,9 @@ class SotnWorld(World):
 
     def set_rules(self):
         set_rules(self.multiworld, self.player)
+
+    def fill_slot_data(self) -> Dict[str, Any]:
+        return self.options.as_dict(*self.option_definitions.keys())
 
     def generate_output(self, output_directory: str) -> None:
         patch_rom(self, output_directory)


### PR DESCRIPTION
This change populates the slot data with all the options values during generation so they can be returned when a client connects to the AP server (e.g. for trackers to know which entrances are open for access logic, and how many bosses are required).